### PR TITLE
Fix the timezone bug

### DIFF
--- a/app/assets/javascripts/AnimateCustomMapMarker.js
+++ b/app/assets/javascripts/AnimateCustomMapMarker.js
@@ -153,7 +153,11 @@
         var opacity = infobox["boxStyle_"]["opacity"];
         if (opacity > 0) {
           opacity -= 0.05;
-          infobox.setOptions({boxStyle: {opacity: opacity}});
+          infobox.setOptions({
+            boxStyle: {
+              opacity: opacity
+            }
+          });
           fadeInfoBox(infobox, time);
         } else {
           infobox.setVisible(false);
@@ -224,7 +228,7 @@
             for (var i = smell_idx; i < smell_markers.length; i++) {
               var smell_m = smell_markers[i];
               var smell_m_data = smell_m.getData();
-              var smell_epochtime_milisec = smell_m_data["observed_at"] * 1000;
+              var smell_epochtime_milisec = correctTimestamp(smell_m_data["observed_at"] * 1000, false, getTimezoneString());
               if (smell_epochtime_milisec <= (current_epochtime_milisec + elapsed_milisec)) {
                 showMarker(smell_m, map);
                 if (animate_smell_text) showText(smell_m, map);
@@ -245,9 +249,9 @@
               var sensor_m_data = sensor_m.getData();
               var sensor_epochtime_milisec;
               if (typeof sensor_m_data["sensor_data_time"] != "undefined") {
-                sensor_epochtime_milisec = sensor_m_data["sensor_data_time"];
+                sensor_epochtime_milisec = correctTimestamp(sensor_m_data["sensor_data_time"], false, getTimezoneString());
               } else {
-                sensor_epochtime_milisec = sensor_m_data["wind_data_time"];
+                sensor_epochtime_milisec = correctTimestamp(sensor_m_data["wind_data_time"], false, getTimezoneString());
               }
               if (sensor_epochtime_milisec <= (current_epochtime_milisec + elapsed_milisec)) {
                 // Show current sensor marker

--- a/app/assets/javascripts/CustomMapMarker.js
+++ b/app/assets/javascripts/CustomMapMarker.js
@@ -76,15 +76,19 @@
 
       // Create HTML content for the info window
       current_icon_size = zoom_level_to_icon_size[init_zoom_level];
+      var d = new Date(correctTimestamp(data["observed_at"] * 1000, false, getTimezoneString()));
       html_content = "";
-      html_content += "<b>Date:</b> " + (new Date(data["observed_at"] * 1000)).toLocaleString() + "<br>";
+      html_content += "<b>Date:</b> " + d.toLocaleString() + " " + moment.tz(d, getTimezoneString()).zoneAbbr() + "<br>";
       html_content += "<b>Smell Rating:</b> " + smell_value + " (" + smell_value_to_text[smell_value - 1] + ")<br>";
       html_content += "<b>Symptoms:</b> " + feelings_symptoms + "<br>";
       html_content += "<b>Smell Description:</b> " + smell_description;
 
       // Create google map marker
       google_map_marker = new google.maps.Marker({
-        position: new google.maps.LatLng({lat: data["latitude"], lng: data["longitude"]}),
+        position: new google.maps.LatLng({
+          lat: data["latitude"],
+          lng: data["longitude"]
+        }),
         icon: generateSmellIcon(smell_value, init_zoom_level, current_icon_size),
         zIndex: smell_value,
         opacity: marker_default_opacity
@@ -137,8 +141,9 @@
       if (data["is_current_day"]) {
         if (typeof wind_speed !== "undefined") {
           var wind_txt = (isNaN(wind_speed) || wind_speed < 0) ? no_data_txt : wind_speed + " MPH";
-          var wind_time = new Date(data["wind_data_time"]);
+          var wind_time = new Date(correctTimestamp(data["wind_data_time"], false, getTimezoneString()));
           var wind_time_txt = " at time " + padTimeString(wind_time.getHours() + 1) + ":" + padTimeString(wind_time.getMinutes() + 1);
+          wind_time_txt += " " + moment.tz(wind_time, getTimezoneString()).zoneAbbr();
           html_content += '<b>Latest Wind Speed:</b> ' + wind_txt + wind_time_txt;
         }
       }
@@ -147,11 +152,17 @@
       // Create google map marker
       image.addEventListener("load", function () {
         google_map_marker = new google.maps.Marker({
-          position: new google.maps.LatLng({lat: data["latitude"], lng: data["longitude"]}),
+          position: new google.maps.LatLng({
+            lat: data["latitude"],
+            lng: data["longitude"]
+          }),
           icon: generateWindOnlySensorIcon(image, wind_direction),
           zIndex: 200,
           opacity: marker_default_opacity,
-          shape: {coords: [50, 50, 12.5], type: "circle"} // Modify click region
+          shape: {
+            coords: [50, 50, 12.5],
+            type: "circle"
+          } // Modify click region
         });
         addMarkerEvent();
         // Fire complete event
@@ -166,7 +177,7 @@
       // TODO: no_data_txt should be different for current day and previous day cases
       var no_data_txt = "No data in last hour";
       var sensor_value = data["sensor_value"];
-      var sensor_data_time = data["sensor_data_time"];
+      var sensor_data_time = correctTimestamp(data["sensor_data_time"], false, getTimezoneString());
       var sensor_time_txt = "";
       var wind_speed = data["wind_speed"];
       var has_sensor = !(isNaN(sensor_value) || sensor_value < 0);
@@ -174,6 +185,7 @@
       if (typeof sensor_data_time !== "undefined" && has_sensor) {
         var sensor_time = new Date(sensor_data_time);
         sensor_time_txt = " at time " + padTimeString(sensor_time.getHours() + 1) + ":" + padTimeString(sensor_time.getMinutes() + 1);
+        sensor_time_txt += " " + moment.tz(sensor_time, getTimezoneString()).zoneAbbr();
       }
 
       // Create HTML content for the info window
@@ -183,8 +195,9 @@
         html_content += "<b>Latest PM<sub>2.5</sub>:</b> " + sensor_txt + sensor_time_txt + "<br>";
         if (typeof wind_speed !== "undefined") {
           var wind_txt = (isNaN(wind_speed) || wind_speed < 0) ? no_data_txt : wind_speed + " MPH";
-          var wind_time = new Date(data["wind_data_time"]);
+          var wind_time = new Date(correctTimestamp(data["wind_data_time"], false, getTimezoneString()));
           var wind_time_txt = " at time " + padTimeString(wind_time.getHours() + 1) + ":" + padTimeString(wind_time.getMinutes() + 1);
+          wind_time_txt += " " + moment.tz(wind_time, getTimezoneString()).zoneAbbr();
           html_content += '<b>Latest Wind Speed:</b> ' + wind_txt + wind_time_txt;
         }
       } else {
@@ -198,11 +211,17 @@
       // Create google map marker
       image.addEventListener("load", function () {
         google_map_marker = new google.maps.Marker({
-          position: new google.maps.LatLng({lat: data["latitude"], lng: data["longitude"]}),
+          position: new google.maps.LatLng({
+            lat: data["latitude"],
+            lng: data["longitude"]
+          }),
           icon: generatePM25SensorIcon(image, wind_direction),
           zIndex: sensor_icon_idx + 5,
           opacity: marker_default_opacity,
-          shape: {coords: [50, 50, 12.5], type: "circle"} // Modify click region
+          shape: {
+            coords: [50, 50, 12.5],
+            type: "circle"
+          } // Modify click region
         });
         addMarkerEvent();
         // Fire complete event
@@ -324,13 +343,14 @@
       // TODO: no_data_txt should be different for current day and previous day cases
       var no_data_txt = "No data in last hour";
       var sensor_value = data["sensor_value"];
-      var sensor_data_time = data["sensor_data_time"];
+      var sensor_data_time = correctTimestamp(data["sensor_data_time"], false, getTimezoneString());
       var sensor_time_txt = "";
       var has_sensor = !(isNaN(sensor_value) || sensor_value < 0);
       var sensor_txt = has_sensor ? sensor_value + " ppb" : no_data_txt;
       if (typeof sensor_data_time !== "undefined" && has_sensor) {
         var sensor_time = new Date(sensor_data_time);
         sensor_time_txt = " at time " + padTimeString(sensor_time.getHours() + 1) + ":" + padTimeString(sensor_time.getMinutes() + 1);
+        sensor_time_txt += " " + moment.tz(sensor_time, getTimezoneString()).zoneAbbr();
       }
 
       // Create HTML content for the info window
@@ -346,7 +366,10 @@
 
       // Create google map marker
       google_map_marker = new google.maps.Marker({
-        position: new google.maps.LatLng({lat: data["latitude"], lng: data["longitude"]}),
+        position: new google.maps.LatLng({
+          lat: data["latitude"],
+          lng: data["longitude"]
+        }),
         icon: generateVOCSensorIcon(sensor_icon_idx, 24),
         zIndex: sensor_icon_idx + 5,
         opacity: marker_default_opacity

--- a/app/assets/javascripts/visualization.js
+++ b/app/assets/javascripts/visualization.js
@@ -127,6 +127,12 @@ var widgets = new edaplotjs.Widgets();
 // Map city ids to home names
 var city_id_to_data;
 
+// Timezone of the current city location
+// For example, Pittsburgh and Louisville should be "America/New_York"
+// Bay Area and Portland should be "America/Los_Angeles"
+// All Regions should be the browser's timezone, which is moment.tz.guess(true)
+var timezone_string = "America/New_York";
+
 function init() {
   var qs = getQueryStringData(); // set data coming from the query string
 
@@ -258,6 +264,24 @@ function setMode(desired_mode) {
   } else {
     setToSmellPgh(mode);
   }
+  if (typeof desired_city_ids !== "undefined" && desired_city_ids.length == 1) {
+    if (desired_city_ids[0] == 1) {
+      // Pittsburgh
+      timezone_string = "America/New_York";
+    } else if (desired_city_ids[0] == 2) {
+      // Louisville
+      timezone_string = "America/New_York";
+    } else if (desired_city_ids[0] == 3) {
+      // Portland
+      timezone_string = "America/Los_Angeles";
+    } else if (desired_city_ids[0] == 4) {
+      // Bay Area
+      timezone_string = "America/Los_Angeles";
+    }
+  } else {
+    // All Regions
+    timezone_string = moment.tz.guess(true);
+  }
 }
 
 function loadDataAndSetUI() {
@@ -379,6 +403,8 @@ function setShareDate() {
         // Update timeline
         var start_time = firstDayOfCurrentMonth(selected_date_obj).getTime();
         var end_time = firstDayOfNextMonth(selected_date_obj).getTime();
+        start_time = correctTimestamp(start_time, true, timezone_string);
+        end_time = correctTimestamp(end_time, true, timezone_string) - 10;
         loadAndUpdateTimeLine(start_time, end_time, function () {
           // Select the correct block
           var max_num_days = daysInMonth(year, month);
@@ -686,7 +712,9 @@ function initCalendarBtn() {
       if (selected_value == -1) {
         loadInitialTimeLine();
       } else {
-        loadAndUpdateTimeLine(selected_time, firstDayOfNextMonth(selected_date_obj).getTime());
+        var corrected_s = correctTimestamp(selected_time, true, timezone_string);
+        var corrected_e = correctTimestamp(firstDayOfNextMonth(selected_date_obj).getTime(), true, timezone_string) - 10;
+        loadAndUpdateTimeLine(corrected_s, corrected_e);
       }
       addGoogleAnalyticEvent("calendar", "click", {
         "dimension5": selected_time.toString()
@@ -849,7 +877,7 @@ function loadAndDrawCalendar() {
 function getInitialTimeRange() {
   var date_obj = firstDayOfPreviousMonth(new Date());
   // The starting time is the first day of the last month
-  var start_time = date_obj.getTime();
+  var start_time = correctTimestamp(date_obj.getTime(), true, timezone_string);
   // The ending time is the current time
   var end_time = Date.now();
   return {
@@ -865,7 +893,7 @@ function loadInitialTimeLine(callback) {
 
 function loadAndUpdateTimeLine(start_time, end_time, callback) {
   loadTimelineData(start_time, end_time, function (data) {
-    timeline.updateBlocks(formatDataForTimeline(data, new Date(end_time)));
+    timeline.updateBlocks(formatDataForTimeline(data, end_time));
     timeline.clearBlockSelection();
     timeline.selectLastBlock();
     if (typeof callback === "function") {
@@ -878,7 +906,7 @@ function loadAndCreateTimeline(callback) {
   // Create the timeline
   var T = getInitialTimeRange();
   loadTimelineData(T["start_time"], T["end_time"], function (data) {
-    createTimeline(formatDataForTimeline(data, new Date(T["end_time"])));
+    createTimeline(formatDataForTimeline(data, T["end_time"]));
   });
 }
 
@@ -936,7 +964,7 @@ function loadAndCreateSmellMarkers(epochtime_milisec) {
   // generate start and end times from epochtime_milisec
   var date_obj = new Date(epochtime_milisec);
   date_obj.setHours(0, 0, 0, 0);
-  var start_time = parseInt(date_obj.getTime() / 1000);
+  var start_time = parseInt(correctTimestamp(date_obj.getTime(), true, timezone_string) / 1000);
   var end_time = start_time + 86399; // one day after the starting time
   $.ajax({
     "url": generateURLForSmellReports({
@@ -1024,7 +1052,7 @@ function generateURL(domain, path, parameters) {
     parameters["latlng_bbox"] = desired_latlng_bbox;
   }
   if (typeof parameters["timezone_string"] === "undefined") {
-    parameters["timezone_string"] = encodeURIComponent(moment.tz.guess(true));
+    parameters["timezone_string"] = timezone_string;
   }
   var api_params = "";
   var parameter_list = [];
@@ -1167,11 +1195,14 @@ function drawCalendar(data) {
   }
 }
 
-function formatDataForTimeline(data, pad_to_date_obj) {
-  var current_date_obj = new Date();
-  if (pad_to_date_obj.getTime() > current_date_obj.getTime()) {
-    pad_to_date_obj = current_date_obj;
+function formatDataForTimeline(data, pad_to_date_timestamp) {
+  var current_date_timestamp = new Date().getTime();
+  current_date_timestamp = correctTimestamp(current_date_timestamp, false, timezone_string);
+  pad_to_date_timestamp = correctTimestamp(pad_to_date_timestamp, false, timezone_string);
+  if (pad_to_date_timestamp > current_date_timestamp) {
+    pad_to_date_timestamp = current_date_timestamp;
   }
+  var pad_to_date_obj = new Date(pad_to_date_timestamp);
   var batch_3d = []; // 3D batch data
   var batch_2d = []; // the inner small 2D batch data for batch_3d
   var sorted_day_str = Object.keys(data).sort();
@@ -1179,7 +1210,7 @@ function formatDataForTimeline(data, pad_to_date_obj) {
 
   // If no data, need to add the current day to the list
   if (sorted_day_str.length == 0) {
-    sorted_day_str = [dataObjectToString(new Date())];
+    sorted_day_str = [dataObjectToString(new Date(current_date_timestamp))];
   }
 
   // If the first one is not the first day of the month, we need to insert it
@@ -1279,8 +1310,10 @@ function createTimeline(data) {
       var end_time = safeGet(first_block_data["epochtime_milisec"], new Date().getTime());
       end_time = firstDayOfCurrentMonth(new Date(end_time)).getTime();
       var start_time = firstDayOfPreviousMonth(new Date(end_time)).getTime();
+      start_time = correctTimestamp(start_time, true, timezone_string);
+      end_time = correctTimestamp(end_time, true, timezone_string) - 10;
       loadTimelineData(start_time, end_time, function (data) {
-        obj.prependBlocks(formatDataForTimeline(data, new Date(end_time)));
+        obj.prependBlocks(formatDataForTimeline(data, end_time));
         obj.setLeftArrowOpacity(1);
         obj.enableLeftArrow();
       });
@@ -1545,6 +1578,7 @@ function hideSensorMarkersByTime(epochtime_milisec) {
 
 function generateSensorDataUrlList(epochtime_milisec, info) {
   var esdr_root_url = "https://esdr.cmucreatelab.org/api/v1/";
+  epochtime_milisec = correctTimestamp(epochtime_milisec, true, timezone_string);
   var epochtime = parseInt(epochtime_milisec / 1000);
   var time_range_url_part = "/export?format=json&from=" + epochtime + "&to=" + (epochtime + 86399);
 
@@ -1818,6 +1852,10 @@ function post(type, data) {
     data: data,
     origin: document.referrer // TODO: Change this (and above) to explicity set a domain we'll be receiving requests from
   });
+}
+
+function getTimezoneString() {
+  return timezone_string;
 }
 
 $(function () {


### PR DESCRIPTION
If I change the timezone on my computer (e.g., to Taipei Time UTC+8), the animation will offset for several hours, which I believe is the wrong behavior. To clarify, when I ran the animation on 7/7/2020, originally, when I was in Pittsburgh (EST time zone), a lot of smell reports showed up in the morning. But when I am in Taiwan, which is the UTC+8 time zone, a lot of the smell reports showed in the evening instead. I think this is because there is a 13 hour difference between EST time and Taiwan time.

In this pull request, I fixed this problem. Please see the correctTimestamp() function in the "util.js" file for details. The function deals with time zone differences and daylight saving issues. I did tests in different time zones (by changing the time zone on my computer) and they all worked. I also hardcoded the time zones based on different cities (in the setMode() function in "visualization.js"). The idea is, if the user wants to view the data from a city (e.g., Pittsburgh), the data and the animation should be displayed in the city's time zone (e.g., Pittsburgh would be "America/New_York"), but not the browser user's time zone.